### PR TITLE
Refatorando código duplicado

### DIFF
--- a/src/components/Calendario/index.tsx
+++ b/src/components/Calendario/index.tsx
@@ -3,9 +3,9 @@ import style from "./Calendario.module.scss";
 import ptBR from "./localizacao/ptBR.json";
 import Kalend, { CalendarEvent, CalendarView, OnEventDragFinish } from "kalend";
 import "kalend/dist/styles/index.css";
-import { useRecoilValue, useSetRecoilState } from "recoil";
+import { useRecoilValue } from "recoil";
 import { listaEventosState } from "../../state/atom";
-import { IEvento } from "../../interfaces/IEvento";
+import useAtualizarEvento from "../../state/hooks/useAtualizarEvento";
 
 interface IKalendEvento {
   id?: number;
@@ -18,7 +18,7 @@ interface IKalendEvento {
 const Calendario: React.FC = () => {
   const eventosKalend = new Map<string, IKalendEvento[]>();
   const eventos = useRecoilValue(listaEventosState);
-  const setListaEventos = useSetRecoilState<IEvento[]>(listaEventosState);
+  const atualizarEvento = useAtualizarEvento();
 
   eventos.forEach((evento) => {
     const chave = evento.inicio.toISOString().slice(0, 10);
@@ -48,14 +48,7 @@ const Calendario: React.FC = () => {
       eventoAtualizado.inicio = new Date(kalendEventoAtualizado.startAt);
       eventoAtualizado.fim = new Date(kalendEventoAtualizado.endAt);
 
-      setListaEventos((listaAntiga) => {
-        const indice = listaAntiga.findIndex((evt) => evt.id === evento.id);
-        return [
-          ...listaAntiga.slice(0, indice),
-          eventoAtualizado,
-          ...listaAntiga.slice(indice + 1),
-        ];
-      });
+      atualizarEvento(eventoAtualizado);
     }
   };
 

--- a/src/components/Evento/EventoCheckbox/index.tsx
+++ b/src/components/Evento/EventoCheckbox/index.tsx
@@ -1,24 +1,16 @@
 import React from "react";
 import { IEvento } from "../../../interfaces/IEvento";
-import { useSetRecoilState } from "recoil";
-import { listaEventosState } from "../../../state/atom";
+import useAtualizarEvento from "../../../state/hooks/useAtualizarEvento";
 
 const EventoCheckbox: React.FC<{ evento: IEvento }> = ({ evento }) => {
-  const setListaEventos = useSetRecoilState<IEvento[]>(listaEventosState);
+  const atualizarEvento = useAtualizarEvento();
   const alterarStatus = () => {
     const eventoAlterado = {
       ...evento,
     };
     eventoAlterado.completo = !eventoAlterado.completo;
 
-    setListaEventos((listaAntiga) => {
-      const indice = listaAntiga.findIndex((evt) => evt.id === evento.id);
-      return [
-        ...listaAntiga.slice(0, indice),
-        eventoAlterado,
-        ...listaAntiga.slice(indice + 1),
-      ];
-    });
+    atualizarEvento(eventoAlterado);
   };
 
   const estilos = [

--- a/src/state/hooks/useAtualizarEvento.ts
+++ b/src/state/hooks/useAtualizarEvento.ts
@@ -1,0 +1,19 @@
+import { useSetRecoilState } from "recoil";
+import { IEvento } from "../../interfaces/IEvento";
+import { listaEventosState } from "../atom";
+
+const useAtualizarEvento = () => {
+  const setListaEventos = useSetRecoilState<IEvento[]>(listaEventosState);
+  return (evento: IEvento) => {
+    return setListaEventos((listaAntiga) => {
+      const indice = listaAntiga.findIndex((evt) => evt.id === evento.id);
+      return [
+        ...listaAntiga.slice(0, indice),
+        evento,
+        ...listaAntiga.slice(indice + 1),
+      ];
+    });
+  };
+};
+
+export default useAtualizarEvento;


### PR DESCRIPTION
Refatorando a função setListaEventos que tava duplicada em duas partes do projeto e centralizando em um hook para facilitar a refatorações e mudanças futuras.